### PR TITLE
Add nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Or run it directly:
 cat README.md | nix run gituhb:ynqa/sig -- --archived
 ```
 
+### Nix (classic)
+
+Fetch the source and use it, e.g. in your shell:
+
+```nix
+let
+  pkgs = import <nixpkgs> {};
+
+  sig = import (fetchFromGitHub {
+    owner = "ynqa";
+    repo = "sig";
+    rev = "v0.1.0";
+    hash = "sha256-KHXBeQFmuA3YO9AN5dkY/fl/z2RdbR6AqSSEGUNrxt4=";
+  });
+in
+  mkShell {
+    packages = [sig];
+  }
+```
+
 ## Keymap
 
 | Key                  | Action

--- a/README.md
+++ b/README.md
@@ -39,21 +39,19 @@ cargo install sigrs
 
 ### Nix (flakes)
 
-Add it as an input to your flake
-
+Add it as an input to your flake:
 ```nix
 inputs = {
   sig.url = 'github:ynqa/sig/<optional-ref>'
 }
 ```
 
-add it to a shell:
-
+Creat a shell with it:
 ```nix
 nix shell gituhb:ynqa/sig
 ```
 
-or run it directly:
+Or run it directly:
 ```nix
 cat README.md | nix run gituhb:ynqa/sig -- --archived
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ brew install ynqa/tap/sigrs
 cargo install sigrs
 ```
 
+### Nix (flakes)
+
+Add it as an input to your flake
+
+```nix
+inputs = {
+  sig.url = 'github:ynqa/sig/<optional-ref>'
+}
+```
+
+add it to a shell:
+
+```nix
+nix shell gituhb:ynqa/sig
+```
+
+or run it directly:
+```nix
+cat README.md | nix run gituhb:ynqa/sig -- --archived
+```
+
 ## Keymap
 
 | Key                  | Action

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ inputs = {
 
 Create a shell with it:
 ```nix
-nix shell gituhb:ynqa/sig
+nix shell github:ynqa/sig
 ```
 
 Or run it directly:
 ```nix
-cat README.md | nix run gituhb:ynqa/sig -- --archived
+cat README.md | nix run github:ynqa/sig -- --archived
 ```
 
 ### Nix (classic)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ inputs = {
 }
 ```
 
-Creat a shell with it:
+Create a shell with it:
 ```nix
 nix shell gituhb:ynqa/sig
 ```

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ Fetch the source and use it, e.g. in your shell:
 let
   pkgs = import <nixpkgs> {};
 
-  sig = import (fetchFromGitHub {
+  sig = pkgs.callPackage (pkgs.fetchFromGitHub {
     owner = "ynqa";
     repo = "sig";
     rev = "v0.1.0";
     hash = "sha256-KHXBeQFmuA3YO9AN5dkY/fl/z2RdbR6AqSSEGUNrxt4=";
-  });
+  }) {};
 in
-  mkShell {
+  pkgs.mkShell {
     packages = [sig];
   }
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitHub,
 }: let
   version = "0.1.0";
   owner = "ynqa";
@@ -11,13 +10,9 @@ in
     pname = "sig";
     inherit version;
 
-    src = fetchFromGitHub {
-      inherit owner repo;
-      rev = "v${version}";
-      hash = "sha256-KHXBeQFmuA3YO9AN5dkY/fl/z2RdbR6AqSSEGUNrxt4=";
-    };
+    src = ./.;
 
-    cargoHash = "sha256-3nNdCz6Yjnnle/sG6kqGCAcoVRNhc4BOteWGDDl5oWs=";
+		cargoHash = "sha256-yz/DPJJxtsHpJLpTMAYfsq9miIs48F+FeSnmkQ707uA=";
 
     meta = {
       description = "Interactive grep (for streaming)";

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}: let
+  version = "0.1.0";
+  owner = "ynqa";
+  repo = "sig";
+in
+  rustPlatform.buildRustPackage {
+    pname = "sig";
+    inherit version;
+
+    src = fetchFromGitHub {
+      inherit owner repo;
+      rev = "v${version}";
+      hash = "sha256-KHXBeQFmuA3YO9AN5dkY/fl/z2RdbR6AqSSEGUNrxt4=";
+    };
+
+    cargoHash = "sha256-3nNdCz6Yjnnle/sG6kqGCAcoVRNhc4BOteWGDDl5oWs=";
+
+    meta = {
+      description = "Interactive grep (for streaming)";
+      homepage = "https://github.com/${owner}/${repo}";
+      license = [lib.licenses.mit];
+      mainProgram = "sig";
+    };
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716619601,
+        "narHash": "sha256-9dUxZf8MOqJH3vjbhrz7LH4qTcnRsPSBU1Q50T7q/X8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "47e03a624662ce399e55c45a5f6da698fc72c797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Interactive grep (for streaming)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    systems,
+  }: let
+    forEachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+  in {
+    formatter = forEachSystem (pkgs: pkgs.alejandra);
+
+    packages = forEachSystem (pkgs: {
+      default = pkgs.callPackage ./default.nix {};
+    });
+  };
+}


### PR DESCRIPTION
This PR introduces a nix flake & default.nix that builds this rust package which allows nix users to use this package.

For people who want to use this *right now*, you can refer to this code as follows:
```nix
github:ynqa/sig/pull/1/head#default
```
Or use my fork directly before merge:
```nix
github:Dich0tomy/sig/feat/add-nix-build-method
```
But note that this ref is volatile and the branch will get deleted after this PR gets merged.