### PR TITLE
Add Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ brew install ynqa/tap/sigrs
 cargo install sigrs
 ```
 
+### Arch Linux
+
+```bash
+pacman -S sig
+```
+
 ### Nix (flakes)
 
 Add it as an input to your flake:


### PR DESCRIPTION
`sig` is now packaged in official repositories: https://archlinux.org/packages/extra/x86_64/sig/ 🥳
